### PR TITLE
feat: support rds

### DIFF
--- a/alicloud-rds/0.0.1/README.md
+++ b/alicloud-rds/0.0.1/README.md
@@ -1,0 +1,79 @@
+# AliCloud RDS
+
+This module provides the following RDS engines of AliCloud.
+
+- MySQL
+- MariaDB
+- PostgreSQL
+
+> Notes:
+> - Provisioning takes almost 10-15 mins without any SQL initialization.
+> - Lockable initializing SQL may cost more time.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_alicloud"></a> [alicloud](#provider\_alicloud) | n/a |
+| <a name="provider_byteset"></a> [byteset](#provider\_byteset) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [alicloud_db_connection.rds](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/db_connection) | resource |
+| [alicloud_db_database.default](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/db_database) | resource |
+| [alicloud_db_instance.rds](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/db_instance) | resource |
+| [alicloud_rds_account.rds](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/rds_account) | resource |
+| [alicloud_security_group.rds](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/security_group) | resource |
+| [alicloud_security_group_rule.allow_all_tcp](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/security_group_rule) | resource |
+| [alicloud_vpc.rds](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/vpc) | resource |
+| [alicloud_vswitch.rds](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/resources/vswitch) | resource |
+| [byteset_pipeline.init_sql](https://registry.terraform.io/providers/seal-io/byteset/latest/docs/resources/pipeline) | resource |
+| [alicloud_db_zones.rds](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/data-sources/db_zones) | data source |
+| [alicloud_vpcs.rds](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/data-sources/vpcs) | data source |
+| [alicloud_vswitches.rds](https://registry.terraform.io/providers/aliyun/alicloud/latest/docs/data-sources/vswitches) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_engine"></a> [engine](#input\_engine) | Select the RDS engine, support serval kinds of 'MySQL', 'MariaDB' and 'PostgreSQL'. | `string` | n/a | yes |
+| <a name="input_architecture"></a> [architecture](#input\_architecture) | Select the RDS architecture, support from 'Standalone' and 'Replication', 'MariaDB' engine doesn't support 'Standalone'. | `string` | n/a | yes |
+| <a name="input_password"></a> [password](#input\_password) | Specify the root password to initialize after launching. | `string` | n/a | yes |
+| <a name="input_username"></a> [username](#input\_username) | Specify the root username to initialize after launching, do not allow 'root' and 'sa'. | `string` | `"rdsusr"` | no |
+| <a name="input_database"></a> [database](#input\_database) | Specify the database name to initialize after launching. | `string` | `"rdsdb"` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Specify the instance type to deploy the RDS engine, pick at least 2C4G type automatically if empty. | `string` | `""` | no |
+| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | Specify the storage type to deploy the RDS engine, pick at least ESSD PL1 if empty. | `string` | `""` | no |
+| <a name="input_init_sql_url"></a> [init\_sql\_url](#input\_init\_sql\_url) | Specify the init SQL download URL to initialize after launching. | `string` | `""` | no |
+| <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Specify to allow publicly accessing. | `string` | `false` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | Specify the existing VPC ID to deploy, create a new one if empty. | `string` | `""` | no |
+| <a name="input_seal_metadata_project_name"></a> [seal\_metadata\_project\_name](#input\_seal\_metadata\_project\_name) | Seal metadata project name. | `string` | `""` | no |
+| <a name="input_seal_metadata_environment_name"></a> [seal\_metadata\_environment\_name](#input\_seal\_metadata\_environment\_name) | Seal metadata environment name. | `string` | `""` | no |
+| <a name="input_seal_metadata_service_name"></a> [seal\_metadata\_service\_name](#input\_seal\_metadata\_service\_name) | Seal metadata service name. | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_db_endpoint"></a> [db\_endpoint](#output\_db\_endpoint) | n/a |
+| <a name="output_db_host"></a> [db\_host](#output\_db\_host) | n/a |
+| <a name="output_db_endpoint_replica"></a> [db\_endpoint\_replica](#output\_db\_endpoint\_replica) | n/a |
+| <a name="output_db_host_replica"></a> [db\_host\_replica](#output\_db\_host\_replica) | n/a |
+| <a name="output_db_driver"></a> [db\_driver](#output\_db\_driver) | n/a |
+| <a name="output_db_port"></a> [db\_port](#output\_db\_port) | n/a |
+| <a name="output_db_name"></a> [db\_name](#output\_db\_name) | n/a |
+| <a name="output_db_username"></a> [db\_username](#output\_db\_username) | n/a |
+| <a name="output_db_password"></a> [db\_password](#output\_db\_password) | n/a |
+<!-- END_TF_DOCS -->

--- a/alicloud-rds/0.0.1/main.tf
+++ b/alicloud-rds/0.0.1/main.tf
@@ -1,0 +1,352 @@
+#
+# Constants.
+#
+locals {
+  engineInfos = tomap({
+    # Ref to https://www.alibabacloud.com/help/zh/apsaradb-for-rds/latest/primary-apsaradb-rds-instance-types.
+
+    # 
+    #
+    # MySQL.
+    #
+
+    "MySQL-5.7" : {
+      "driver" : "mysql",
+      "port" : 3306,
+      "engine" : "MySQL",
+      "engineVersion" : "5.7",
+      "instanceTypeStandalone" : "mysql.n2.medium.1",
+      "instanceTypeReplication" : "mysql.n2.medium.2c",
+      "parameters" : [
+        {
+          "name" : "innodb_flush_log_at_trx_commit",
+          "value" : "2",
+        },
+        {
+          "name" : "sync_binlog",
+          "value" : "1000",
+        }
+      ],
+    },
+    "MySQL-8.0" : {
+      "driver" : "mysql",
+      "port" : 3306,
+      "engine" : "MySQL",
+      "engineVersion" : "8.0",
+      "instanceTypeStandalone" : "mysql.n2.medium.1",
+      "instanceTypeReplication" : "mysql.n2.medium.2c",
+      "parameters" : [
+        {
+          "name" : "innodb_flush_log_at_trx_commit",
+          "value" : "2",
+        },
+        {
+          "name" : "sync_binlog",
+          "value" : "1000",
+        }
+      ],
+    },
+
+    #
+    # MariaDB.
+    #
+
+    "MariaDB-10.3" : {
+      "driver" : "mariadb",
+      "port" : 3306,
+      "engine" : "MariaDB",
+      "engineVersion" : "10.3",
+      "instanceTypeStandalone" : null,
+      "instanceTypeReplication" : "mariadb.n2.medium.2c",
+      "parameters" : [
+        {
+          "name" : "innodb_flush_log_at_trx_commit",
+          "value" : "2",
+        },
+        {
+          "name" : "sync_binlog",
+          "value" : "1000",
+        }
+      ],
+    },
+
+    #
+    # PostgreSQL.
+    #
+
+    "PostgreSQL-13" : {
+      "driver" : "postgres",
+      "port" : 5432,
+      "engine" : "PostgreSQL",
+      "engineVersion" : "13.0",
+      "instanceTypeStandalone" : "pg.n2.2c.1m",
+      "instanceTypeReplication" : "pg.n2.2c.2m",
+      "parameters" : [
+        {
+          "name" : "synchronous_commit",
+          "value" : "off",
+        }
+      ],
+    },
+    "PostgreSQL-14" : {
+      "driver" : "postgres",
+      "port" : 5432,
+      "engine" : "PostgreSQL",
+      "engineVersion" : "14.0",
+      "instanceTypeStandalone" : "pg.n2.2c.1m",
+      "instanceTypeReplication" : "pg.n2.2c.2m",
+      "parameters" : [
+        {
+          "name" : "synchronous_commit",
+          "value" : "off",
+        }
+      ],
+    },
+    "PostgreSQL-15" : {
+      "driver" : "postgres",
+      "port" : 5432,
+      "engine" : "PostgreSQL",
+      "engineVersion" : "15.0",
+      "instanceTypeStandalone" : "pg.n2.2c.1m",
+      "instanceTypeReplication" : "pg.n2.2c.2m",
+      "parameters" : [
+        {
+          "name" : "synchronous_commit",
+          "value" : "off",
+        }
+      ],
+    },
+
+  })
+}
+
+#
+# Prepare locals.
+#
+
+locals {
+  seal_metadata_project_name     = coalesce(var.seal_metadata_project_name, "example")
+  seal_metadata_environment_name = coalesce(var.seal_metadata_environment_name, "example")
+  seal_metadata_service_name     = coalesce(var.seal_metadata_service_name, "alicloudrds")
+
+  identifier = join("-", [local.seal_metadata_project_name, local.seal_metadata_environment_name, local.var.seal_metadata_service_name])
+}
+
+locals {
+  engineInfo = lookup(local.engineInfos, var.engine)
+
+  architecture = var.architecture
+
+  engine         = lookup(local.engineInfo, "engine")
+  engine_version = lookup(local.engineInfo, "engineVersion")
+  driver         = lookup(local.engineInfo, "driver")
+  port           = lookup(local.engineInfo, "port")
+  database       = var.database
+  username       = var.username
+  password       = var.password
+
+  sql_init            = var.init_sql_url != ""
+  publicly_accessible = var.publicly_accessible || local.sql_init
+  tags = {
+    "seal_project"     = local.seal_metadata_project_name
+    "seal_environment" = local.seal_metadata_environment_name
+    "seal_service"     = local.seal_metadata_service_name
+  }
+  instance_type   = coalesce(var.instance_type, lookup(local.engineInfo, format("instanceType%s", local.architecture)))
+  storage_type    = coalesce(var.storage_type, "cloud_essd")
+  vpc_create      = var.vpc_id == ""
+  vpc_create_cidr = "10.0.0.0/16"
+}
+
+#
+# Ensure VPC.
+#
+
+data "alicloud_db_zones" "rds" {
+  count = local.vpc_create ? 1 : 0
+
+  engine                   = local.engine
+  engine_version           = local.engine_version
+  category                 = local.architecture == "Replication" ? "HighAvailability" : "Basic"
+  db_instance_storage_type = local.storage_type
+
+  lifecycle {
+    postcondition {
+      condition     = local.architecture == "Replication" ? length(self.ids) > 1 : length(self.ids) > 0
+      error_message = "Failed to get Avaialbe Zones"
+    }
+  }
+}
+
+resource "alicloud_vpc" "rds" {
+  count = local.vpc_create ? 1 : 0
+
+  vpc_name   = local.identifier
+  cidr_block = local.vpc_create_cidr
+
+  tags = local.tags
+}
+
+locals {
+  vpc_create_zones   = try(data.alicloud_db_zones.rds.0.ids, [])
+  vpc_create_subnets = [for k, v in local.vpc_create_zones : cidrsubnet(local.vpc_create_cidr, 8, k)]
+}
+
+resource "alicloud_vswitch" "rds" {
+  count = local.vpc_create ? length(local.vpc_create_subnets) : 0
+
+  vpc_id     = alicloud_vpc.rds.0.id
+  zone_id    = element(local.vpc_create_zones, count.index)
+  cidr_block = element(local.vpc_create_subnets, count.index)
+
+  tags = local.tags
+}
+
+data "alicloud_vpcs" "rds" {
+  count = !local.vpc_create ? 1 : 0
+
+  ids = [var.vpc_id]
+
+  lifecycle {
+    postcondition {
+      condition     = length(self.ids) == 1
+      error_message = "Failed to get available VPC"
+    }
+  }
+}
+
+data "alicloud_vswitches" "rds" {
+  count = !local.vpc_create ? 1 : 0
+
+  vpc_id = var.vpc_id
+
+  lifecycle {
+    postcondition {
+      condition     = local.architecture == "Replication" ? length(self.ids) > 1 : length(self.ids) > 0
+      error_message = "Failed to get available VSwitch"
+    }
+  }
+}
+
+locals {
+  vpc_id      = local.vpc_create ? alicloud_vpc.rds.0.id : data.alicloud_vpcs.rds.0.vpcs.0.id
+  vpc_cidr    = local.vpc_create ? alicloud_vpc.rds.0.cidr_block : data.alicloud_vpcs.rds.0.vpcs.0.cidr_block
+  vpc_subnets = local.vpc_create ? alicloud_vswitch.rds.*.id : data.alicloud_vswitches.rds.0.vswitches.*.id
+  vpc_zones   = local.vpc_create ? alicloud_vswitch.rds.*.zone_id : data.alicloud_vswitches.rds.0.vswitches.*.zone_id
+}
+
+#
+# Ensure Security Group.
+#
+
+resource "alicloud_security_group" "rds" {
+  name   = local.identifier
+  vpc_id = local.vpc_id
+
+  tags = local.tags
+}
+
+resource "alicloud_security_group_rule" "allow_all_tcp" {
+  cidr_ip = local.publicly_accessible ? "0.0.0.0/0" : local.vpc_cidr
+
+  type              = "ingress"
+  ip_protocol       = "tcp"
+  nic_type          = "intranet"
+  policy            = "accept"
+  port_range        = format("%d/%d", local.port, local.port)
+  priority          = 1
+  security_group_id = alicloud_security_group.rds.id
+}
+
+#
+# Create Database.
+#
+
+resource "alicloud_db_instance" "rds" {
+  security_ips = [local.publicly_accessible ? "0.0.0.0/0" : local.vpc_cidr]
+
+  instance_name  = local.identifier
+  engine         = local.engine
+  engine_version = local.engine_version
+  instance_type  = local.instance_type
+
+  db_instance_storage_type = local.storage_type
+  storage_auto_scale       = contains(["MySQL", "PostgreSQL"], local.engine) ? "Enable" : "Disable"
+  storage_threshold        = contains(["MySQL", "PostgreSQL"], local.engine) ? "20" : null
+  storage_upper_bound      = contains(["MySQL", "PostgreSQL"], local.engine) ? "100" : null
+  instance_storage         = contains(["MySQL", "PostgreSQL"], local.engine) ? "20" : "100"
+
+
+  category           = local.architecture == "Replication" ? "HighAvailability" : "Basic"
+  vpc_id             = local.vpc_id
+  vswitch_id         = local.architecture == "Replication" ? join(",", [local.vpc_subnets.0, local.vpc_subnets.1]) : local.vpc_subnets.0
+  security_group_ids = [alicloud_security_group.rds.id]
+  zone_id            = local.vpc_zones.0
+  zone_id_slave_a    = local.architecture == "Replication" ? local.vpc_zones.1 : null
+
+  deletion_protection = contains(["MySQL", "PostgreSQL", "MariaDB"], local.engine) ? false : null
+
+  dynamic "parameters" {
+    for_each = lookup(local.engineInfo, "parameters")
+    content {
+      name  = parameters.value["name"]
+      value = parameters.value["value"]
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "alicloud_db_database" "default" {
+  instance_id = alicloud_db_instance.rds.id
+  name        = local.database
+}
+
+resource "alicloud_rds_account" "rds" {
+  db_instance_id   = alicloud_db_instance.rds.id
+  account_type     = "Super"
+  account_name     = local.username
+  account_password = local.password
+}
+
+resource "alicloud_db_connection" "rds" {
+  instance_id = alicloud_db_instance.rds.id
+  port        = local.port
+}
+
+#
+# Get host/endpoint.
+#
+
+locals {
+  host             = alicloud_db_connection.rds.connection_string
+  host_replica     = local.architecture == "Replication" ? local.host : null
+  endpoint         = alicloud_db_connection.rds.ip_address
+  endpoint_replica = local.architecture == "Replication" ? local.endpoint : null
+}
+
+#
+# Seed Database.
+#
+
+resource "byteset_pipeline" "init_sql" {
+  count = local.sql_init ? 1 : 0
+
+  source = {
+    address = var.init_sql_url
+  }
+
+  destination = {
+    address = format("%s://%s:%s@%s/%s%s",
+      local.driver,
+      local.username,
+      local.password,
+      (contains(["mysql", "mariadb"], local.driver) ? format("tcp(%s:%d)", local.host, local.port) : format("%s:%d", local.host, local.port)),
+      local.database,
+      (contains(["postgres"], local.driver) ? "?sslmode=disable" : "")
+    )
+
+    salt = alicloud_db_instance.rds.id
+  }
+}
+

--- a/alicloud-rds/0.0.1/outputs.tf
+++ b/alicloud-rds/0.0.1/outputs.tf
@@ -1,0 +1,36 @@
+output "db_endpoint" {
+  value = local.endpoint
+}
+
+output "db_host" {
+  value = local.host
+}
+
+output "db_endpoint_replica" {
+  value = local.endpoint_replica
+}
+
+output "db_host_replica" {
+  value = local.host_replica
+}
+
+output "db_driver" {
+  value = local.driver
+}
+
+output "db_port" {
+  value = local.port
+}
+
+output "db_name" {
+  value = local.database
+}
+
+output "db_username" {
+  value = local.username
+}
+
+output "db_password" {
+  sensitive = true
+  value     = local.password
+}

--- a/alicloud-rds/0.0.1/variables.tf
+++ b/alicloud-rds/0.0.1/variables.tf
@@ -1,0 +1,146 @@
+##############
+# Basic Group
+##############
+
+# @group "Basic"
+# @label "Engine"
+# @options ["MySQL-5.7","MySQL-8.0","MariaDB-10.3","PostgreSQL-13","PostgreSQL-14","PostgreSQL-15"]
+variable "engine" {
+  type        = string
+  description = "Select the RDS engine, support serval kinds of 'MySQL', 'MariaDB' and 'PostgreSQL'."
+
+  validation {
+    condition     = contains(["MySQL-5.7", "MySQL-8.0", "MariaDB-10.3", "PostgreSQL-13", "PostgreSQL-14", "PostgreSQL-15"], var.engine)
+    error_message = "Invalid engine"
+  }
+}
+
+# @group "Basic"
+# @label "Architecture"
+# @options ["Standalone","Replication"]
+variable "architecture" {
+  type        = string
+  description = "Select the RDS architecture, support from 'Standalone' and 'Replication', 'MariaDB' engine doesn't support 'Standalone'."
+
+  validation {
+    condition     = contains(["Standalone", "Replication"], var.architecture)
+    error_message = "Invalid architecture"
+  }
+}
+
+# @group "Basic"
+# @label "Password"
+variable "password" {
+  type        = string
+  description = "Specify the root password to initialize after launching."
+
+  validation {
+    condition     = var.password != "" ? can(regex("^[A-Za-z0-9\\!#\\$%\\^&\\*\\(\\)_\\+\\-=]{8,32}", var.password)) : true
+    error_message = "Invalid password"
+  }
+}
+
+# @group "Basic"
+# @label "Username"
+variable "username" {
+  type        = string
+  description = "Specify the root username to initialize after launching, do not allow 'root' and 'sa'."
+  default     = "rdsusr"
+
+  validation {
+    condition     = !contains(["root", "sa"], var.username)
+    error_message = format("Invalid username: %s", var.username)
+  }
+
+  validation {
+    condition     = can(regex("^[^pg][a-z][a-z0-9_]{0,61}[a-z0-9]$", var.username))
+    error_message = format("Invalid username: %s", var.username)
+  }
+}
+
+# @group "Basic"
+# @label "Database"
+variable "database" {
+  type        = string
+  description = "Specify the database name to initialize after launching."
+  default     = "rdsdb"
+
+  validation {
+    condition     = can(regex("^[a-z][-a-z0-9_]{0,61}[a-z0-9]$", var.database))
+    error_message = format("Invalid database: %s", var.database)
+  }
+}
+
+#################
+# Advanced Group
+#################
+
+# @group "Advanced"
+# @label "Instance Type"
+variable "instance_type" {
+  type        = string
+  description = "Specify the instance type to deploy the RDS engine, pick at least 2C4G type automatically if empty."
+  default     = ""
+}
+
+# @group "Advanced"
+# @label "Storage Type"
+variable "storage_type" {
+  type        = string
+  description = "Specify the storage type to deploy the RDS engine, pick at least ESSD PL1 if empty."
+  default     = ""
+}
+
+# @group "Advanced"
+# @label "Init SQL URL"
+variable "init_sql_url" {
+  type        = string
+  description = "Specify the init SQL download URL to initialize after launching."
+  default     = ""
+
+  validation {
+    condition     = var.init_sql_url != "" ? can(regex("^(?:https?://)+(?:[^/.\\s]+\\.)*", var.init_sql_url)) : true
+    error_message = "Invalid init sql url"
+  }
+}
+
+# @group "Advanced"
+# @label "Publicly Accessible"
+variable "publicly_accessible" {
+  type        = string
+  description = "Specify to allow publicly accessing."
+  default     = false
+}
+
+# @group "Advanced"
+# @label "VPC ID"
+variable "vpc_id" {
+  type        = string
+  description = "Specify the existing VPC ID to deploy, create a new one if empty."
+  default     = ""
+}
+
+###########################
+# Injection Group (Hidden)
+###########################
+
+# @hidden
+variable "seal_metadata_project_name" {
+  type        = string
+  description = "Seal metadata project name."
+  default     = ""
+}
+
+# @hidden
+variable "seal_metadata_environment_name" {
+  type        = string
+  description = "Seal metadata environment name."
+  default     = ""
+}
+
+# @hidden
+variable "seal_metadata_service_name" {
+  type        = string
+  description = "Seal metadata service name."
+  default     = ""
+}

--- a/alicloud-rds/0.0.1/versions.tf
+++ b/alicloud-rds/0.0.1/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    alicloud = {
+      source = "aliyun/alicloud"
+    }
+
+    byteset = {
+      source = "seal-io/byteset"
+    }
+  }
+}

--- a/alicloud-rds/examples/replication/main.tf
+++ b/alicloud-rds/examples/replication/main.tf
@@ -1,0 +1,200 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    byteset = {
+      source = "seal-io/byteset"
+    }
+  }
+}
+
+provider "alicloud" {
+}
+
+provider "byteset" {
+}
+
+variable "with_mysql" {
+  type    = bool
+  default = false
+}
+
+variable "with_mariadb" {
+  type    = bool
+  default = false
+}
+
+variable "with_postgres" {
+  type    = bool
+  default = false
+}
+
+resource "random_string" "password" {
+  length  = 16
+  special = false
+}
+
+########
+# MySQL
+########
+
+module "mysql" {
+  count = var.with_mysql ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "MySQL-8.0"
+  architecture = "Replication"
+  password     = random_string.password.result
+
+  init_sql_url = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/mysql-lg.sql"
+
+  seal_metadata_service_name = "mysql"
+}
+
+output "mysql_db_endpoint" {
+  value = try(module.mysql.0.db_endpoint, null)
+}
+
+output "mysql_db_host" {
+  value = try(module.mysql.0.db_host, null)
+}
+
+output "mysql_db_endpoint_replica" {
+  value = try(module.mysql.0.db_endpoint_replica, null)
+}
+
+output "mysql_db_host_replica" {
+  value = try(module.mysql.0.db_host_replica, null)
+}
+
+output "mysql_db_driver" {
+  value = try(module.mysql.0.db_driver, null)
+}
+
+output "mysql_db_port" {
+  value = try(module.mysql.0.db_port, null)
+}
+
+output "mysql_db_name" {
+  value = try(module.mysql.0.db_name, null)
+}
+
+output "mysql_db_username" {
+  value = try(module.mysql.0.db_username, null)
+}
+
+output "mysql_db_password" {
+  sensitive = true
+  value     = try(module.mysql.0.db_password, null)
+}
+
+##########
+# MariaDB
+##########
+
+module "mariadb" {
+  count = var.with_mariadb ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "MariaDB-10.3"
+  architecture = "Replication"
+  password     = random_string.password.result
+
+  init_sql_url = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/mysql.sql"
+
+  seal_metadata_service_name = "mariadb"
+}
+
+output "mariadb_db_endpoint" {
+  value = try(module.mariadb.0.db_endpoint, null)
+}
+
+output "mariadb_db_host" {
+  value = try(module.mariadb.0.db_host, null)
+}
+
+output "mariadb_db_endpoint_replica" {
+  value = try(module.mariadb.0.db_endpoint_replica, null)
+}
+
+output "mariadb_db_host_replica" {
+  value = try(module.mariadb.0.db_host_replica, null)
+}
+
+output "mariadb_db_driver" {
+  value = try(module.mariadb.0.db_driver, null)
+}
+
+output "mariadb_db_port" {
+  value = try(module.mariadb.0.db_port, null)
+}
+
+output "mariadb_db_name" {
+  value = try(module.mariadb.0.db_name, null)
+}
+
+output "mariadb_db_username" {
+  value = try(module.mariadb.0.db_username, null)
+}
+
+output "mariadb_db_password" {
+  sensitive = true
+  value     = try(module.mariadb.0.db_password, null)
+}
+
+############
+#PostgreSQL
+############
+
+module "postgres" {
+  count = var.with_postgres ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "PostgreSQL-13"
+  architecture = "Replication"
+  password     = random_string.password.result
+
+  init_sql_url = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/postgres.sql"
+
+  seal_metadata_service_name = "postgres"
+}
+
+output "postgres_db_endpoint" {
+  value = try(module.postgres.0.db_endpoint, null)
+}
+
+output "postgres_db_host" {
+  value = try(module.postgres.0.db_host, null)
+}
+
+output "postgres_db_endpoint_replica" {
+  value = try(module.postgres.0.db_endpoint_replica, null)
+}
+
+output "postgres_db_host_replica" {
+  value = try(module.postgres.0.db_host_replica, null)
+}
+
+output "postgres_db_driver" {
+  value = try(module.postgres.0.db_driver, null)
+}
+
+output "postgres_db_port" {
+  value = try(module.postgres.0.db_port, null)
+}
+
+output "postgres_db_name" {
+  value = try(module.postgres.0.db_name, null)
+}
+
+output "postgres_db_username" {
+  value = try(module.postgres.0.db_username, null)
+}
+
+output "postgres_db_password" {
+  sensitive = true
+  value     = try(module.postgres.0.db_password, null)
+}

--- a/alicloud-rds/examples/standalone/main.tf
+++ b/alicloud-rds/examples/standalone/main.tf
@@ -1,0 +1,124 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    byteset = {
+      source = "seal-io/byteset"
+    }
+  }
+}
+
+provider "alicloud" {
+}
+
+provider "byteset" {
+}
+
+variable "with_mysql" {
+  type    = bool
+  default = false
+}
+
+variable "with_postgres" {
+  type    = bool
+  default = false
+}
+
+resource "random_string" "password" {
+  length  = 16
+  special = false
+}
+
+########
+# MySQL
+########
+
+module "mysql" {
+  count = var.with_mysql ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "MySQL-8.0"
+  architecture = "Standalone"
+  password     = random_string.password.result
+
+  init_sql_url = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/mysql-lg.sql"
+
+  seal_metadata_service_name = "mysql"
+}
+
+output "mysql_db_endpoint" {
+  value = try(module.mysql.0.db_endpoint, null)
+}
+
+output "mysql_db_host" {
+  value = try(module.mysql.0.db_host, null)
+}
+
+output "mysql_db_driver" {
+  value = try(module.mysql.0.db_driver, null)
+}
+
+output "mysql_db_port" {
+  value = try(module.mysql.0.db_port, null)
+}
+
+output "mysql_db_name" {
+  value = try(module.mysql.0.db_name, null)
+}
+
+output "mysql_db_username" {
+  value = try(module.mysql.0.db_username, null)
+}
+
+output "mysql_db_password" {
+  sensitive = true
+  value     = try(module.mysql.0.db_password, null)
+}
+
+#############
+# PostgreSQL
+#############
+
+module "postgres" {
+  count = var.with_postgres ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "PostgreSQL-13"
+  architecture = "Standalone"
+  password     = random_string.password.result
+
+  init_sql_url = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/postgres.sql"
+
+  seal_metadata_service_name = "postgres"
+}
+
+output "postgres_db_endpoint" {
+  value = try(module.postgres.0.db_endpoint, null)
+}
+
+output "postgres_db_host" {
+  value = try(module.postgres.db_host, null)
+}
+
+output "postgres_db_driver" {
+  value = try(module.postgres.0.db_driver, null)
+}
+
+output "postgres_db_port" {
+  value = try(module.postgres.0.db_port, null)
+}
+
+output "postgres_db_name" {
+  value = try(module.postgres.0.db_name, null)
+}
+
+output "postgres_db_username" {
+  value = try(module.postgres.0.db_username, null)
+}
+
+output "postgres_db_password" {
+  sensitive = true
+  value     = try(module.postgres.0.db_password, null)
+}

--- a/aws-rds/0.0.1/README.md
+++ b/aws-rds/0.0.1/README.md
@@ -1,46 +1,81 @@
 # AWS RDS
 
-This module provides a streamlined way to provision and manage Amazon RDS instances, which are fully managed relational databases in the cloud. With this module, you can easily define and configure your RDS instances and related resources, such as security groups and parameter groups, using a simple and intuitive syntax.
+This module provides the following RDS engines of AWS.
 
-In addition to provisioning RDS instances, this module also generates an RDS access endpoint as output. This endpoint provides a direct connection to your RDS instance, allowing you to easily access and manage your database. The endpoint can be used in your application code or scripts.
+- MySQL
+- MariaDB
+- PostgreSQL
 
+> Notes:
+> - Provisioning takes almost 5-10 mins without any SQL initialization.
+> - Lockable initializing SQL may cost more time.
+
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_byteset"></a> [byteset](#provider\_byteset) | n/a |
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 2.77.0 |
+No modules.
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_db_instance.education](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
-| [aws_db_parameter_group.education](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) | resource |
-| [aws_db_subnet_group.education](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
+| [aws_db_instance.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
+| [aws_db_instance.rds_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
+| [aws_db_parameter_group.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) | resource |
+| [aws_db_subnet_group.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
+| [aws_internet_gateway.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
+| [aws_route.rds_internet_gateway](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_security_group.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_security_group_rule.allow_all_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_subnet.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_vpc.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+| [byteset_pipeline.init_sql](https://registry.terraform.io/providers/seal-io/byteset/latest/docs/resources/pipeline) | resource |
+| [aws_availability_zones.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_subnets.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_vpc.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_db_password"></a> [db\_password](#input\_db\_password) | RDS root user password | `any` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | `"ap-northeast-1"` | no |
+| <a name="input_engine"></a> [engine](#input\_engine) | Select the RDS engine, support serval kinds of 'MySQL', 'MariaDB' and 'PostgreSQL'. | `string` | n/a | yes |
+| <a name="input_architecture"></a> [architecture](#input\_architecture) | Select the RDS architecture, support from 'Standalone' and 'Replication'. | `string` | n/a | yes |
+| <a name="input_password"></a> [password](#input\_password) | Specify the root password to initialize after launching. | `string` | n/a | yes |
+| <a name="input_username"></a> [username](#input\_username) | Specify the root username to initialize after launching. | `string` | `"rdsusr"` | no |
+| <a name="input_database"></a> [database](#input\_database) | Specify the database name to initialize after launching. | `string` | `"rdsdb"` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Specify the instance type to deploy the RDS engine, pick burstable 2C4G type automatically if empty. | `string` | `""` | no |
+| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | Specify the storage type to deploy the RDS engine, pick GP2 if empty. | `string` | `""` | no |
+| <a name="input_init_sql_url"></a> [init\_sql\_url](#input\_init\_sql\_url) | Specify the init SQL download URL to initialize after launching. | `string` | `""` | no |
+| <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Specify to allow publicly accessing. | `string` | `false` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | Specify the existing VPC ID to deploy, create a new one if empty. | `string` | `""` | no |
+| <a name="input_seal_metadata_project_name"></a> [seal\_metadata\_project\_name](#input\_seal\_metadata\_project\_name) | Seal metadata project name. | `string` | `""` | no |
+| <a name="input_seal_metadata_environment_name"></a> [seal\_metadata\_environment\_name](#input\_seal\_metadata\_environment\_name) | Seal metadata environment name. | `string` | `""` | no |
+| <a name="input_seal_metadata_service_name"></a> [seal\_metadata\_service\_name](#input\_seal\_metadata\_service\_name) | Seal metadata service name. | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_rds_hostname"></a> [rds\_hostname](#output\_rds\_hostname) | RDS instance hostname |
-| <a name="output_rds_port"></a> [rds\_port](#output\_rds\_port) | RDS instance port |
-| <a name="output_rds_username"></a> [rds\_username](#output\_rds\_username) | RDS instance root username |
+| <a name="output_db_endpoint"></a> [db\_endpoint](#output\_db\_endpoint) | n/a |
+| <a name="output_db_host"></a> [db\_host](#output\_db\_host) | n/a |
+| <a name="output_db_endpoint_replica"></a> [db\_endpoint\_replica](#output\_db\_endpoint\_replica) | n/a |
+| <a name="output_db_host_replica"></a> [db\_host\_replica](#output\_db\_host\_replica) | n/a |
+| <a name="output_db_driver"></a> [db\_driver](#output\_db\_driver) | n/a |
+| <a name="output_db_port"></a> [db\_port](#output\_db\_port) | n/a |
+| <a name="output_db_name"></a> [db\_name](#output\_db\_name) | n/a |
+| <a name="output_db_username"></a> [db\_username](#output\_db\_username) | n/a |
+| <a name="output_db_password"></a> [db\_password](#output\_db\_password) | n/a |
+<!-- END_TF_DOCS -->

--- a/aws-rds/0.0.1/main.tf
+++ b/aws-rds/0.0.1/main.tf
@@ -1,74 +1,493 @@
-provider "aws" {
-  region = var.region
+#
+# Constants.
+#
+locals {
+  engineInfos = tomap({
+    # Ref to https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html.
+
+    # 
+    #
+    # MySQL.
+    #
+
+    "MySQL-5.7" : {
+      "driver" : "mysql",
+      "port" : 3306,
+      "engine" : "mysql",
+      "engineVersion" : "5.7",
+      "instanceType" : "db.t3.medium",
+      "parameterFamily" : "mysql5.7",
+      "parameters" : [
+        {
+          "name" : "innodb_log_buffer_size",
+          "value" : "268435456",
+        },
+        {
+          "name" : "innodb_log_file_size",
+          "value" : "1073741824",
+        },
+        {
+          "name" : "innodb_flush_log_at_trx_commit",
+          "value" : "2",
+        },
+        {
+          "name" : "sync_binlog",
+          "value" : "1000",
+        }
+      ],
+    },
+    "MySQL-8.0" : {
+      "driver" : "mysql",
+      "port" : 3306,
+      "engine" : "mysql",
+      "engineVersion" : "8.0",
+      "instanceType" : "db.t3.medium",
+      "parameterFamily" : "mysql8.0",
+      "parameters" : [
+        {
+          "name" : "innodb_log_buffer_size",
+          "value" : "268435456",
+        },
+        {
+          "name" : "innodb_log_file_size",
+          "value" : "1073741824",
+        },
+        {
+          "name" : "innodb_flush_log_at_trx_commit",
+          "value" : "2",
+        },
+        {
+          "name" : "sync_binlog",
+          "value" : "1000",
+        }
+      ],
+    },
+
+    #
+    # MariaDB.
+    #
+
+    "MariaDB-10.3" : {
+      "driver" : "mariadb",
+      "port" : 3306,
+      "engine" : "mariadb",
+      "engineVersion" : "10.3.39",
+      "instanceType" : "db.t3.medium",
+      "parameterFamily" : "mariadb10.3",
+      "parameters" : [
+        {
+          "name" : "innodb_log_buffer_size",
+          "value" : "268435456",
+        },
+        {
+          "name" : "innodb_log_file_size",
+          "value" : "1073741824",
+        },
+        {
+          "name" : "innodb_flush_log_at_trx_commit",
+          "value" : "2",
+        },
+        {
+          "name" : "sync_binlog",
+          "value" : "1000",
+        }
+      ],
+    },
+
+    "MariaDB-10.4" : {
+      "driver" : "mariadb",
+      "port" : 3306,
+      "engine" : "mariadb",
+      "engineVersion" : "10.4.29",
+      "instanceType" : "db.t3.medium",
+      "parameterFamily" : "mariadb10.4",
+      "parameters" : [
+        {
+          "name" : "innodb_log_buffer_size",
+          "value" : "268435456",
+        },
+        {
+          "name" : "innodb_log_file_size",
+          "value" : "1073741824",
+        },
+        {
+          "name" : "innodb_flush_log_at_trx_commit",
+          "value" : "2",
+        },
+        {
+          "name" : "sync_binlog",
+          "value" : "1000",
+        }
+      ],
+    },
+
+    "MariaDB-10.5" : {
+      "driver" : "mariadb",
+      "port" : 3306,
+      "engine" : "mariadb",
+      "engineVersion" : "10.5.20",
+      "instanceType" : "db.t3.medium",
+      "parameterFamily" : "mariadb10.5",
+      "parameters" : [
+        {
+          "name" : "innodb_log_buffer_size",
+          "value" : "268435456",
+        },
+        {
+          "name" : "innodb_log_file_size",
+          "value" : "1073741824",
+        },
+        {
+          "name" : "innodb_flush_log_at_trx_commit",
+          "value" : "2",
+        },
+        {
+          "name" : "sync_binlog",
+          "value" : "1000",
+        }
+      ],
+    },
+
+    "MariaDB-10.6" : {
+      "driver" : "mariadb",
+      "port" : 3306,
+      "engine" : "mariadb",
+      "engineVersion" : "10.6.13",
+      "instanceType" : "db.t3.medium",
+      "parameterFamily" : "mariadb10.6",
+      "parameters" : [
+        {
+          "name" : "innodb_log_buffer_size",
+          "value" : "268435456",
+        },
+        {
+          "name" : "innodb_log_file_size",
+          "value" : "1073741824",
+        },
+        {
+          "name" : "innodb_flush_log_at_trx_commit",
+          "value" : "2",
+        },
+        {
+          "name" : "sync_binlog",
+          "value" : "1000",
+        }
+      ],
+    },
+
+    #
+    # PostgreSQL.
+    #
+
+    "PostgreSQL-13" : {
+      "driver" : "postgres",
+      "port" : 5432,
+      "engine" : "postgres",
+      "engineVersion" : "13.11",
+      "instanceType" : "db.t3.medium",
+      "parameterFamily" : "postgres13",
+      "parameters" : [
+        {
+          "name" : "synchronous_commit",
+          "value" : "off",
+        }
+      ],
+    },
+    "PostgreSQL-14" : {
+      "driver" : "postgres",
+      "port" : 5432,
+      "engine" : "postgres",
+      "engineVersion" : "14.8",
+      "instanceType" : "db.t3.medium",
+      "parameterFamily" : "postgres14",
+      "parameters" : [
+        {
+          "name" : "synchronous_commit",
+          "value" : "off",
+        }
+      ],
+    },
+    "PostgreSQL-15" : {
+      "driver" : "postgres",
+      "port" : 5432,
+      "engine" : "postgres",
+      "engineVersion" : "15.3",
+      "instanceType" : "db.t3.medium",
+      "parameterFamily" : "postgres15",
+      "parameters" : [
+        {
+          "name" : "synchronous_commit",
+          "value" : "off",
+        }
+      ],
+    },
+
+  })
 }
 
-data "aws_availability_zones" "available" {}
+#
+# Prepare locals.
+#
 
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "2.77.0"
+locals {
+  seal_metadata_project_name     = coalesce(var.seal_metadata_project_name, "example")
+  seal_metadata_environment_name = coalesce(var.seal_metadata_environment_name, "example")
+  seal_metadata_service_name     = coalesce(var.seal_metadata_service_name, "awsrds")
 
-  name                 = "education"
-  cidr                 = "10.0.0.0/16"
-  azs                  = data.aws_availability_zones.available.names
-  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  identifier = join("-", [local.seal_metadata_project_name, local.seal_metadata_environment_name, local.var.seal_metadata_service_name])
+}
+
+locals {
+  engineInfo = lookup(local.engineInfos, var.engine)
+
+  architecture = var.architecture
+
+  engine         = lookup(local.engineInfo, "engine")
+  engine_version = lookup(local.engineInfo, "engineVersion")
+  driver         = lookup(local.engineInfo, "driver")
+  port           = lookup(local.engineInfo, "port")
+  database       = var.database
+  username       = var.username
+  password       = var.password
+
+  sql_init            = var.init_sql_url != ""
+  publicly_accessible = var.publicly_accessible || local.sql_init
+  tags = {
+    "seal_project"     = local.seal_metadata_project_name
+    "seal_environment" = local.seal_metadata_environment_name
+    "seal_service"     = local.seal_metadata_service_name
+  }
+  instance_type   = coalesce(var.instance_type, lookup(local.engineInfo, "instanceType"))
+  storage_type    = coalesce(var.storage_type, "gp2")
+  vpc_create      = var.vpc_id == ""
+  vpc_create_cidr = "10.0.0.0/16"
+}
+
+#
+# Ensure VPC.
+#
+
+data "aws_availability_zones" "rds" {
+  count = local.vpc_create ? 1 : 0
+
+  state = "available"
+
+  lifecycle {
+    postcondition {
+      condition     = local.architecture == "Replication" ? length(self.names) > 1 : length(self.names) > 0
+      error_message = "Failed to get Avaialbe Zones"
+    }
+  }
+}
+
+resource "aws_vpc" "rds" {
+  count = local.vpc_create ? 1 : 0
+
+  instance_tenancy     = "default"
   enable_dns_hostnames = true
   enable_dns_support   = true
+  cidr_block           = local.vpc_create_cidr
+
+  tags = local.tags
 }
 
-resource "aws_db_subnet_group" "education" {
-  name       = "education"
-  subnet_ids = module.vpc.public_subnets
+locals {
+  vpc_create_zones   = try(data.aws_availability_zones.rds.0.names, [])
+  vpc_create_subnets = [for k, v in local.vpc_create_zones : cidrsubnet(local.vpc_create_cidr, 8, k)]
+}
 
-  tags = {
-    Name = "Education"
+resource "aws_subnet" "rds" {
+  count = local.vpc_create ? length(local.vpc_create_subnets) : 0
+
+  vpc_id            = aws_vpc.rds.0.id
+  availability_zone = element(local.vpc_create_zones, count.index)
+  cidr_block        = element(local.vpc_create_subnets, count.index)
+
+  tags = local.tags
+}
+
+resource "aws_internet_gateway" "rds" {
+  count = local.vpc_create ? 1 : 0
+
+  vpc_id = aws_vpc.rds.0.id
+
+  tags = local.tags
+}
+
+resource "aws_route" "rds_internet_gateway" {
+  count = local.vpc_create ? 1 : 0
+
+  destination_cidr_block = "0.0.0.0/0"
+  route_table_id         = aws_vpc.rds.0.default_route_table_id
+  gateway_id             = aws_internet_gateway.rds.0.id
+}
+
+data "aws_vpc" "rds" {
+  count = !local.vpc_create ? 1 : 0
+
+  id = var.vpc_id
+}
+
+data "aws_subnets" "rds" {
+  count = !local.vpc_create ? 1 : 0
+
+  filter {
+    name   = "vpc-id"
+    values = [var.vpc_id]
+  }
+
+  lifecycle {
+    postcondition {
+      condition     = local.architecture == "Replication" ? length(self.ids) > 1 : length(self.ids) > 0
+      error_message = "Failed to get available Subnet."
+    }
   }
 }
+
+locals {
+  vpc_id      = local.vpc_create ? aws_vpc.rds.0.id : data.aws_vpc.rds.0.id
+  vpc_cidr    = local.vpc_create ? aws_vpc.rds.0.cidr_block : data.aws_vpc.rds.0.cidr_block
+  vpc_subnets = local.vpc_create ? aws_subnet.rds.*.id : data.aws_subnets.rds.0.ids
+}
+
+#
+# Ensure Security Group.
+#
 
 resource "aws_security_group" "rds" {
-  name   = "education_rds"
-  vpc_id = module.vpc.vpc_id
+  name   = local.identifier
+  vpc_id = local.vpc_id
 
-  ingress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  tags = local.tags
+}
 
-  egress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+resource "aws_security_group_rule" "allow_all_tcp" {
+  cidr_blocks = [local.publicly_accessible ? "0.0.0.0/0" : local.vpc_cidr]
 
-  tags = {
-    Name = "education_rds"
+  type              = "ingress"
+  from_port         = local.port
+  to_port           = local.port
+  protocol          = "tcp"
+  security_group_id = aws_security_group.rds.id
+}
+
+#
+# Create Database.
+#
+
+resource "aws_db_subnet_group" "rds" {
+  name       = local.identifier
+  subnet_ids = local.vpc_subnets
+
+  tags = local.tags
+}
+
+resource "aws_db_parameter_group" "rds" {
+  name   = local.identifier
+  family = lookup(local.engineInfo, "parameterFamily")
+
+  dynamic "parameter" {
+    for_each = lookup(local.engineInfo, "parameters")
+    content {
+      name         = parameter.value["name"]
+      value        = parameter.value["value"]
+      apply_method = "pending-reboot"
+    }
   }
 }
 
-resource "aws_db_parameter_group" "education" {
-  name   = "education"
-  family = "postgres14"
+resource "aws_db_instance" "rds" {
+  publicly_accessible = local.publicly_accessible
 
-  parameter {
-    name  = "log_connections"
-    value = "1"
-  }
-}
+  identifier     = local.identifier
+  engine         = local.engine
+  engine_version = local.engine_version
+  instance_class = local.instance_type
 
-resource "aws_db_instance" "education" {
-  identifier             = "education"
-  instance_class         = "db.t3.micro"
-  allocated_storage      = 5
-  engine                 = "postgres"
-  engine_version         = "14.1"
-  username               = "edu"
-  password               = var.db_password
-  db_subnet_group_name   = aws_db_subnet_group.education.name
+  db_name  = local.database
+  port     = local.port
+  username = local.username
+  password = local.password
+
+  storage_type          = local.storage_type
+  max_allocated_storage = 100
+  allocated_storage     = 20
+
+  multi_az               = local.architecture == "Replication"
+  db_subnet_group_name   = aws_db_subnet_group.rds.id
   vpc_security_group_ids = [aws_security_group.rds.id]
-  parameter_group_name   = aws_db_parameter_group.education.name
-  publicly_accessible    = true
-  skip_final_snapshot    = true
+
+  apply_immediately       = true
+  backup_retention_period = 1
+  skip_final_snapshot     = true
+  deletion_protection     = false
+
+  parameter_group_name = aws_db_parameter_group.rds.name
+
+  tags = local.tags
+}
+
+resource "aws_db_instance" "rds_replica" {
+  count = local.architecture == "Replication" ? 1 : 0
+
+  publicly_accessible = aws_db_instance.rds.publicly_accessible
+
+  identifier     = join("-", [aws_db_instance.rds.identifier, "replica"])
+  engine         = aws_db_instance.rds.engine
+  engine_version = aws_db_instance.rds.engine_version
+  instance_class = aws_db_instance.rds.instance_class
+
+  replicate_source_db = aws_db_instance.rds.arn
+  port                = aws_db_instance.rds.port
+
+  storage_type = aws_db_instance.rds.storage_type
+
+  multi_az               = false
+  db_subnet_group_name   = aws_db_instance.rds.db_subnet_group_name
+  vpc_security_group_ids = aws_db_instance.rds.vpc_security_group_ids
+
+  apply_immediately       = true
+  backup_retention_period = 0
+  skip_final_snapshot     = true
+  deletion_protection     = false
+
+  parameter_group_name = aws_db_instance.rds.parameter_group_name
+
+  tags = local.tags
+}
+
+#
+# Get host/endpoint.
+#
+
+locals {
+  host             = aws_db_instance.rds.address
+  host_replica     = try(aws_db_instance.rds_replica.0.address, null)
+  endpoint         = local.host
+  endpoint_replica = local.host_replica
+}
+
+#
+# Seed Database.
+#
+
+resource "byteset_pipeline" "init_sql" {
+  count = local.sql_init ? 1 : 0
+
+  source = {
+    address = var.init_sql_url
+  }
+
+  destination = {
+    address = format("%s://%s:%s@%s/%s%s",
+      local.driver,
+      local.username,
+      local.password,
+      ((contains(["mysql", "mariadb"], local.driver)) ? format("tcp(%s:%d)", local.host, local.port) : format("%s:%d", local.host, local.port)),
+      local.database,
+      (contains(["postgres"], local.driver) ? "?sslmode=disable" : "")
+    )
+
+    salt = aws_db_instance.rds.id
+  }
 }

--- a/aws-rds/0.0.1/outputs.tf
+++ b/aws-rds/0.0.1/outputs.tf
@@ -1,17 +1,36 @@
-output "rds_hostname" {
-  description = "RDS instance hostname"
-  value       = aws_db_instance.education.address
-  sensitive   = true
+output "db_endpoint" {
+  value = local.endpoint
 }
 
-output "rds_port" {
-  description = "RDS instance port"
-  value       = aws_db_instance.education.port
-  sensitive   = true
+output "db_host" {
+  value = local.host
 }
 
-output "rds_username" {
-  description = "RDS instance root username"
-  value       = aws_db_instance.education.username
-  sensitive   = true
+output "db_endpoint_replica" {
+  value = local.endpoint_replica
+}
+
+output "db_host_replica" {
+  value = local.host_replica
+}
+
+output "db_driver" {
+  value = local.driver
+}
+
+output "db_port" {
+  value = local.port
+}
+
+output "db_name" {
+  value = local.database
+}
+
+output "db_username" {
+  value = local.username
+}
+
+output "db_password" {
+  sensitive = true
+  value     = local.password
 }

--- a/aws-rds/0.0.1/variables.tf
+++ b/aws-rds/0.0.1/variables.tf
@@ -1,9 +1,141 @@
-variable "region" {
-  default     = "ap-northeast-1"
-  description = "AWS region"
+##############
+# Basic Group
+##############
+
+# @group "Basic"
+# @label "Engine"
+# @options ["MySQL-5.7","MySQL-8.0","MariaDB-10.3","MariaDB-10.4","MariaDB-10.5","MariaDB-10.6","PostgreSQL-13","PostgreSQL-14","PostgreSQL-15"]
+variable "engine" {
+  type        = string
+  description = "Select the RDS engine, support serval kinds of 'MySQL', 'MariaDB' and 'PostgreSQL'."
+
+  validation {
+    condition     = contains(["MySQL-5.7", "MySQL-8.0", "MariaDB-10.3", "MariaDB-10.4", "MariaDB-10.5", "MariaDB-10.6", "PostgreSQL-13", "PostgreSQL-14", "PostgreSQL-15"], var.engine)
+    error_message = "Invalid engine"
+  }
 }
 
-variable "db_password" {
-  description = "RDS root user password"
-  sensitive   = true
+# @group "Basic"
+# @label "Architecture"
+# @options ["Standalone","Replication"]
+variable "architecture" {
+  type        = string
+  description = "Select the RDS architecture, support from 'Standalone' and 'Replication'."
+
+  validation {
+    condition     = contains(["Standalone", "Replication"], var.architecture)
+    error_message = "Invalid architecture"
+  }
+}
+
+# @group "Basic"
+# @label "Password"
+variable "password" {
+  type        = string
+  description = "Specify the root password to initialize after launching."
+
+  validation {
+    condition     = var.password != "" ? can(regex("^[A-Za-z0-9\\!#\\$%\\^&\\*\\(\\)_\\+\\-=]{8,32}", var.password)) : true
+    error_message = "Invalid password"
+  }
+}
+
+# @group "Basic"
+# @label "Username"
+variable "username" {
+  type        = string
+  description = "Specify the root username to initialize after launching."
+  default     = "rdsusr"
+
+  validation {
+    condition     = can(regex("^[A-Za-z_]{0,15}[a-z0-9]$", var.username))
+    error_message = format("Invalid username: %s", var.username)
+  }
+}
+
+# @group "Basic"
+# @label "Database"
+variable "database" {
+  type        = string
+  description = "Specify the database name to initialize after launching."
+  default     = "rdsdb"
+
+  validation {
+    condition     = can(regex("^[a-z][-a-z0-9_]{0,61}[a-z0-9]$", var.database))
+    error_message = format("Invalid database: %s", var.database)
+  }
+}
+
+#################
+# Advanced Group
+#################
+
+# @group "Advanced"
+# @label "Instance Type"
+variable "instance_type" {
+  type        = string
+  description = "Specify the instance type to deploy the RDS engine, pick burstable 2C4G type automatically if empty."
+  default     = ""
+}
+
+# @group "Advanced"
+# @label "Storage Type"
+variable "storage_type" {
+  type        = string
+  description = "Specify the storage type to deploy the RDS engine, pick GP2 if empty."
+  default     = ""
+}
+
+# @group "Advanced"
+# @label "Init SQL URL"
+variable "init_sql_url" {
+  type        = string
+  description = "Specify the init SQL download URL to initialize after launching."
+  default     = ""
+
+  validation {
+    condition     = var.init_sql_url != "" ? can(regex("^(?:https?://)+(?:[^/.\\s]+\\.)*", var.init_sql_url)) : true
+    error_message = "Invalid init sql url"
+  }
+}
+
+# @group "Advanced"
+# @label "Publicly Accessible"
+variable "publicly_accessible" {
+  type        = string
+  description = "Specify to allow publicly accessing."
+  default     = false
+}
+
+# @group "Advanced"
+# @label "VPC ID"
+variable "vpc_id" {
+  type        = string
+  description = "Specify the existing VPC ID to deploy, create a new one if empty."
+  default     = ""
+}
+
+###########################
+# Injection Group (Hidden)
+###########################
+
+# @hidden
+variable "seal_metadata_project_name" {
+  type        = string
+  description = "Seal metadata project name."
+  default     = ""
+}
+
+# @hidden
+variable "seal_metadata_environment_name" {
+  type        = string
+  description = "Seal metadata environment name."
+  default     = ""
+}
+
+# @hidden
+variable "seal_metadata_service_name" {
+  type        = string
+  description = "Seal metadata service name."
+  default     = ""
 }

--- a/aws-rds/0.0.1/versions.tf
+++ b/aws-rds/0.0.1/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+
+    byteset = {
+      source = "seal-io/byteset"
+    }
+  }
+}

--- a/aws-rds/examples/replication/main.tf
+++ b/aws-rds/examples/replication/main.tf
@@ -1,0 +1,203 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    byteset = {
+      source = "seal-io/byteset"
+    }
+  }
+}
+
+provider "aws" {
+}
+
+provider "byteset" {
+}
+
+variable "with_mysql" {
+  type    = bool
+  default = false
+}
+
+variable "with_mariadb" {
+  type    = bool
+  default = false
+}
+
+variable "with_postgres" {
+  type    = bool
+  default = false
+}
+
+resource "random_string" "password" {
+  length  = 16
+  special = false
+}
+
+########
+# MySQL
+########
+
+module "mysql" {
+  count = var.with_mysql ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "MySQL-8.0"
+  architecture = "Replication"
+  password     = random_string.password.result
+  username     = "root"
+
+  init_sql_url = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/mysql-lg.sql"
+
+  seal_metadata_service_name = "mysql"
+}
+
+output "mysql_db_endpoint" {
+  value = try(module.mysql.0.db_endpoint, null)
+}
+
+output "mysql_db_host" {
+  value = try(module.mysql.0.db_host, null)
+}
+
+output "mysql_db_endpoint_replica" {
+  value = try(module.mysql.0.db_endpoint_replica, null)
+}
+
+output "mysql_db_host_replica" {
+  value = try(module.mysql.0.db_host_replica, null)
+}
+
+output "mysql_db_driver" {
+  value = try(module.mysql.0.db_driver, null)
+}
+
+output "mysql_db_port" {
+  value = try(module.mysql.0.db_port, null)
+}
+
+output "mysql_db_name" {
+  value = try(module.mysql.0.db_name, null)
+}
+
+output "mysql_db_username" {
+  value = try(module.mysql.0.db_username, null)
+}
+
+output "mysql_db_password" {
+  sensitive = true
+  value     = try(module.mysql.0.db_password, null)
+}
+
+##########
+# MariaDB
+##########
+
+module "mariadb" {
+  count = var.with_mariadb ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "MariaDB-10.3"
+  architecture = "Replication"
+  password     = random_string.password.result
+  username     = "root"
+
+  init_sql_url = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/mysql.sql"
+
+  seal_metadata_service_name = "mariadb"
+}
+
+output "mariadb_db_endpoint" {
+  value = try(module.mariadb.0.db_endpoint, null)
+}
+
+output "mariadb_db_host" {
+  value = try(module.mariadb.0.db_host, null)
+}
+
+output "mariadb_db_endpoint_replica" {
+  value = try(module.mariadb.0.db_endpoint_replica, null)
+}
+
+output "mariadb_db_host_replica" {
+  value = try(module.mariadb.0.db_host_replica, null)
+}
+
+output "mariadb_db_driver" {
+  value = try(module.mariadb.0.db_driver, null)
+}
+
+output "mariadb_db_port" {
+  value = try(module.mariadb.0.db_port, null)
+}
+
+output "mariadb_db_name" {
+  value = try(module.mariadb.0.db_name, null)
+}
+
+output "mariadb_db_username" {
+  value = try(module.mariadb.0.db_username, null)
+}
+
+output "mariadb_db_password" {
+  sensitive = true
+  value     = try(module.mariadb.0.db_password, null)
+}
+
+############
+#PostgreSQL
+############
+
+module "postgres" {
+  count = var.with_postgres ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "PostgreSQL-13"
+  architecture = "Replication"
+  password     = random_string.password.result
+  username     = "root"
+
+  init_sql_url = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/postgres-lg.sql"
+
+  seal_metadata_service_name = "postgres"
+}
+
+output "postgres_db_endpoint" {
+  value = try(module.postgres.0.db_endpoint, null)
+}
+
+output "postgres_db_host" {
+  value = try(module.postgres.0.db_host, null)
+}
+
+output "postgres_db_endpoint_replica" {
+  value = try(module.postgres.0.db_endpoint_replica, null)
+}
+
+output "postgres_db_host_replica" {
+  value = try(module.postgres.0.db_host_replica, null)
+}
+
+output "postgres_db_driver" {
+  value = try(module.postgres.0.db_driver, null)
+}
+
+output "postgres_db_port" {
+  value = try(module.postgres.0.db_port, null)
+}
+
+output "postgres_db_name" {
+  value = try(module.postgres.0.db_name, null)
+}
+
+output "postgres_db_username" {
+  value = try(module.postgres.0.db_username, null)
+}
+
+output "postgres_db_password" {
+  sensitive = true
+  value     = try(module.postgres.0.db_password, null)
+}

--- a/aws-rds/examples/standalone/main.tf
+++ b/aws-rds/examples/standalone/main.tf
@@ -1,0 +1,179 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    byteset = {
+      source = "seal-io/byteset"
+    }
+  }
+}
+
+provider "aws" {
+}
+
+provider "byteset" {
+}
+
+variable "with_mysql" {
+  type    = bool
+  default = false
+}
+
+variable "with_mariadb" {
+  type    = bool
+  default = false
+}
+
+variable "with_postgres" {
+  type    = bool
+  default = false
+}
+
+resource "random_string" "password" {
+  length  = 16
+  special = false
+}
+
+########
+# MySQL
+########
+
+module "mysql" {
+  count = var.with_mysql ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "MySQL-8.0"
+  architecture = "Standalone"
+  password     = random_string.password.result
+  username     = "root"
+
+  init_sql_url = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/mysql-lg.sql"
+
+  seal_metadata_service_name = "mysql"
+}
+
+output "mysql_db_endpoint" {
+  value = try(module.mysql.0.db_endpoint, null)
+}
+
+output "mysql_db_host" {
+  value = try(module.mysql.0.db_host, null)
+}
+
+output "mysql_db_driver" {
+  value = try(module.mysql.0.db_driver, null)
+}
+
+output "mysql_db_port" {
+  value = try(module.mysql.0.db_port, null)
+}
+
+output "mysql_db_name" {
+  value = try(module.mysql.0.db_name, null)
+}
+
+output "mysql_db_username" {
+  value = try(module.mysql.0.db_username, null)
+}
+
+output "mysql_db_password" {
+  sensitive = true
+  value     = try(module.mysql.0.db_password, null)
+}
+
+##########
+# MariaDB
+##########
+
+module "mariadb" {
+  count = var.with_mariadb ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "MariaDB-10.3"
+  architecture = "Standalone"
+  password     = random_string.password.result
+  username     = "root"
+
+  init_sql_url = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/mysql.sql"
+
+  seal_metadata_service_name = "mariadb"
+}
+
+output "mariadb_db_endpoint" {
+  value = try(module.mariadb.0.db_endpoint, null)
+}
+
+output "mariadb_db_host" {
+  value = try(module.mariadb.0.db_host, null)
+}
+
+output "mariadb_db_driver" {
+  value = try(module.mariadb.0.db_driver, null)
+}
+
+output "mariadb_db_port" {
+  value = try(module.mariadb.0.db_port, null)
+}
+
+output "mariadb_db_name" {
+  value = try(module.mariadb.0.db_name, null)
+}
+
+output "mariadb_db_username" {
+  value = try(module.mariadb.0.db_username, null)
+}
+
+output "mariadb_db_password" {
+  sensitive = true
+  value     = try(module.mariadb.0.db_password, null)
+}
+
+############
+#PostgreSQL
+############
+
+module "postgres" {
+  count = var.with_postgres ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "PostgreSQL-13"
+  architecture = "Standalone"
+  password     = random_string.password.result
+  username     = "root"
+
+  init_sql_url = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/postgres-lg.sql"
+
+  seal_metadata_service_name = "postgres"
+}
+
+output "postgres_db_endpoint" {
+  value = try(module.postgres.0.db_endpoint, null)
+}
+
+output "postgres_db_host" {
+  value = try(module.postgres.0.db_host, null)
+}
+
+output "postgres_db_driver" {
+  value = try(module.postgres.0.db_driver, null)
+}
+
+output "postgres_db_port" {
+  value = try(module.postgres.0.db_port, null)
+}
+
+output "postgres_db_name" {
+  value = try(module.postgres.0.db_name, null)
+}
+
+output "postgres_db_username" {
+  value = try(module.postgres.0.db_username, null)
+}
+
+output "postgres_db_password" {
+  sensitive = true
+  value     = try(module.postgres.0.db_password, null)
+}

--- a/rds-seeder/0.0.1/README.md
+++ b/rds-seeder/0.0.1/README.md
@@ -1,0 +1,47 @@
+# RDS Seeder
+
+This module seeds any RDS for Development/Testing.
+
+> Notes:
+> - Lockable initializing SQL may cost more time.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_byteset"></a> [byteset](#provider\_byteset) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [byteset_pipeline.rds](https://registry.terraform.io/providers/seal-io/byteset/latest/docs/resources/pipeline) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_source_address"></a> [source\_address](#input\_source\_address) | Specify the seeding source address started with 'file://' or 'http(s)://' schema. | `string` | n/a | yes |
+| <a name="input_destination_address"></a> [destination\_address](#input\_destination\_address) | Specify the seeding destiantion address. | `string` | n/a | yes |
+| <a name="input_destination_conn_max"></a> [destination\_conn\_max](#input\_destination\_conn\_max) | Specify the connection maximum value of destination. | `number` | `5` | no |
+| <a name="input_seal_metadata_project_name"></a> [seal\_metadata\_project\_name](#input\_seal\_metadata\_project\_name) | Seal metadata project name. | `string` | `""` | no |
+| <a name="input_seal_metadata_environment_name"></a> [seal\_metadata\_environment\_name](#input\_seal\_metadata\_environment\_name) | Seal metadata environment name. | `string` | `""` | no |
+| <a name="input_seal_metadata_service_name"></a> [seal\_metadata\_service\_name](#input\_seal\_metadata\_service\_name) | Seal metadata service name. | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_pipeline_id"></a> [pipeline\_id](#output\_pipeline\_id) | n/a |
+<!-- END_TF_DOCS -->

--- a/rds-seeder/0.0.1/main.tf
+++ b/rds-seeder/0.0.1/main.tf
@@ -1,0 +1,40 @@
+#
+# Prepare locals.
+#
+
+locals {
+  seal_metadata_project_name     = coalesce(var.seal_metadata_project_name, "example")
+  seal_metadata_environment_name = coalesce(var.seal_metadata_environment_name, "example")
+  seal_metadata_service_name     = coalesce(var.seal_metadata_service_name, "rdsseeder")
+
+  identifier = join("-", [local.seal_metadata_project_name, local.seal_metadata_environment_name, local.seal_metadata_service_name])
+}
+
+locals {
+  source_address       = var.source_address
+  destination_address  = var.destination_address
+  destination_conn_max = var.destination_conn_max
+}
+
+#
+# Create Pipeline.
+#
+
+resource "byteset_pipeline" "rds" {
+  source = {
+    address = local.source_address
+  }
+
+  destination = {
+    address  = local.destination_address
+    conn_max = local.destination_conn_max
+    salt     = local.identifier
+  }
+}
+
+#
+# Get id.
+#
+locals {
+  id = byteset_pipeline.rds.id
+}

--- a/rds-seeder/0.0.1/outputs.tf
+++ b/rds-seeder/0.0.1/outputs.tf
@@ -1,0 +1,3 @@
+output "pipeline_id" {
+  value = local.id
+}

--- a/rds-seeder/0.0.1/variables.tf
+++ b/rds-seeder/0.0.1/variables.tf
@@ -1,0 +1,59 @@
+##############
+# Basic Group
+##############
+
+# @group "Basic"
+# @label "Source"
+variable "source_address" {
+  type        = string
+  description = "Specify the seeding source address started with 'file://' or 'http(s)://' schema."
+
+  validation {
+    condition     = can(regex("^(?:(https|http|file)://)+(?:[^/.\\s]+\\.)*", var.source_address))
+    error_message = "Invalid source address"
+  }
+}
+
+# @group "Basic"
+# @label "Destination"
+variable "destination_address" {
+  type        = string
+  description = "Specify the seeding destiantion address."
+}
+
+#################
+# Advanced Group
+#################
+
+# @group "Advanced"
+# @label "Destination Connection Maximum"
+variable "destination_conn_max" {
+  type        = number
+  description = "Specify the connection maximum value of destination."
+  default     = 25
+}
+
+###########################
+# Injection Group (Hidden)
+###########################
+
+# @hidden
+variable "seal_metadata_project_name" {
+  type        = string
+  description = "Seal metadata project name."
+  default     = ""
+}
+
+# @hidden
+variable "seal_metadata_environment_name" {
+  type        = string
+  description = "Seal metadata environment name."
+  default     = ""
+}
+
+# @hidden
+variable "seal_metadata_service_name" {
+  type        = string
+  description = "Seal metadata service name."
+  default     = ""
+}

--- a/rds-seeder/0.0.1/versions.tf
+++ b/rds-seeder/0.0.1/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    byteset = {
+      source = "seal-io/byteset"
+    }
+  }
+}

--- a/rds-seeder/examples/aws-rds/main.tf
+++ b/rds-seeder/examples/aws-rds/main.tf
@@ -1,0 +1,49 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    byteset = {
+      source = "seal-io/byteset"
+    }
+  }
+}
+
+provider "aws" {
+}
+
+provider "byteset" {
+}
+
+resource "random_string" "password" {
+  length  = 16
+  special = false
+}
+
+locals {
+  password = random_string.password.result
+}
+
+module "aws" {
+  source = "../../../aws-rds/0.0.1"
+
+  engine              = "MySQL-8.0"
+  architecture        = "Standalone"
+  password            = local.password
+  publicly_accessible = true
+}
+
+module "seed" {
+  source = "../../0.0.1"
+
+  depends_on = [module.aws]
+
+  source_address = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/mysql.sql"
+  destination_address = format("%s://%s:%s@%s/%s%s",
+    module.aws.db_driver,
+    module.aws.db_username,
+    module.aws.db_password,
+    (contains(["mysql", "mariadb"], module.aws.db_driver) ? format("tcp(%s:%d)", module.aws.db_host, module.aws.db_port) : format("%s:%d", module.aws.db_host, module.aws.db_port)),
+    module.aws.db_name,
+    (contains(["postgres"], module.aws.db_driver) ? "?sslmode=disable" : "")
+  )
+}

--- a/rds/0.0.1/README.md
+++ b/rds/0.0.1/README.md
@@ -1,0 +1,67 @@
+# RDS
+
+This module provides the following RDS engines of Kubernetes via [Bitnami Charts](https://github.com/bitnami/charts).
+
+- MySQL
+- MariaDB
+- PostgreSQL
+
+> Notes:
+> - Lockable initializing SQL may cost more time.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_helm"></a> [helm](#provider\_helm) | n/a |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [helm_release.rds](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_service_v1.rds](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/service_v1) | data source |
+| [kubernetes_service_v1.rds_replica](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/service_v1) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_engine"></a> [engine](#input\_engine) | Select the RDS engine, support serval kinds of 'MySQL', 'MariaDB' and 'PostgreSQL'. | `string` | n/a | yes |
+| <a name="input_architecture"></a> [architecture](#input\_architecture) | Select the RDS architecture, support from 'Standalone' and 'Replication'. | `string` | n/a | yes |
+| <a name="input_password"></a> [password](#input\_password) | Specify the root password to initialize after launching. | `string` | n/a | yes |
+| <a name="input_username"></a> [username](#input\_username) | Specify the root username to initialize after launching, 'MySQL' and 'MariaDB' engines don't allow 'root'. | `string` | `"rdsusr"` | no |
+| <a name="input_database"></a> [database](#input\_database) | Specify the database name to initialize after launching. | `string` | `"rdsdb"` | no |
+| <a name="input_emphemeral_storage"></a> [emphemeral\_storage](#input\_emphemeral\_storage) | Specify to use emphemeral storage, which is nice for testing. | `bool` | `false` | no |
+| <a name="input_init_sql_url"></a> [init\_sql\_url](#input\_init\_sql\_url) | Specify the init SQL download URL to initialize after launching. | `string` | `""` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Specify the Kubernetes namespace to deploy, generate automatically if empty. | `string` | `""` | no |
+| <a name="input_seal_metadata_project_name"></a> [seal\_metadata\_project\_name](#input\_seal\_metadata\_project\_name) | Seal metadata project name. | `string` | `""` | no |
+| <a name="input_seal_metadata_environment_name"></a> [seal\_metadata\_environment\_name](#input\_seal\_metadata\_environment\_name) | Seal metadata environment name. | `string` | `""` | no |
+| <a name="input_seal_metadata_service_name"></a> [seal\_metadata\_service\_name](#input\_seal\_metadata\_service\_name) | Seal metadata service name. | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_db_endpoint"></a> [db\_endpoint](#output\_db\_endpoint) | n/a |
+| <a name="output_db_host"></a> [db\_host](#output\_db\_host) | n/a |
+| <a name="output_db_endpoint_replica"></a> [db\_endpoint\_replica](#output\_db\_endpoint\_replica) | n/a |
+| <a name="output_db_host_replica"></a> [db\_host\_replica](#output\_db\_host\_replica) | n/a |
+| <a name="output_db_driver"></a> [db\_driver](#output\_db\_driver) | n/a |
+| <a name="output_db_port"></a> [db\_port](#output\_db\_port) | n/a |
+| <a name="output_db_name"></a> [db\_name](#output\_db\_name) | n/a |
+| <a name="output_db_username"></a> [db\_username](#output\_db\_username) | n/a |
+| <a name="output_db_password"></a> [db\_password](#output\_db\_password) | n/a |
+<!-- END_TF_DOCS -->

--- a/rds/0.0.1/main.tf
+++ b/rds/0.0.1/main.tf
@@ -1,0 +1,200 @@
+#
+# Constants.
+#
+locals {
+  engineInfos = tomap({
+    #
+    # MySQL.
+    #
+
+    "MySQL-5.7" : {
+      "driver" : "mysql",
+      "port" : 3306,
+      "chart" : "mysql",
+      "repository" : "bitnami/mysql",
+      "tag" : "5.7"
+    },
+    "MySQL-8.0" : {
+      "driver" : "mysql",
+      "port" : 3306,
+      "chart" : "mysql",
+      "repository" : "bitnami/mysql",
+      "tag" : "8.0"
+    },
+
+    #
+    # MariaDB.
+    #
+
+    "MariaDB-10.3" : {
+      "driver" : "mariadb",
+      "port" : 3306,
+      "chart" : "mariadb",
+      "repository" : "bitnami/mariadb",
+      "tag" : "10.3"
+    },
+    "MariaDB-10.4" : {
+      "driver" : "mariadb",
+      "port" : 3306,
+      "chart" : "mariadb",
+      "repository" : "bitnami/mariadb",
+      "tag" : "10.4"
+    },
+    "MariaDB-10.5" : {
+      "driver" : "mariadb",
+      "port" : 3306,
+      "chart" : "mariadb",
+      "repository" : "bitnami/mariadb",
+      "tag" : "10.5"
+    },
+    "MariaDB-10.6" : {
+      "driver" : "mariadb",
+      "port" : 3306,
+      "chart" : "mariadb",
+      "repository" : "bitnami/mariadb",
+      "tag" : "10.6"
+    },
+
+    #
+    # PostgreSQL.
+    #
+
+    "PostgreSQL-13" : {
+      "driver" : "postgresql",
+      "port" : 5432,
+      "chart" : "postgresql",
+      "repository" : "bitnami/postgresql",
+      "tag" : "13"
+    },
+    "PostgreSQL-14" : {
+      "driver" : "postgresql",
+      "port" : 5432,
+      "chart" : "postgresql",
+      "repository" : "bitnami/postgresql",
+      "tag" : "14"
+    },
+    "PostgreSQL-15" : {
+      "driver" : "postgresql",
+      "port" : 5432,
+      "chart" : "postgresql",
+      "repository" : "bitnami/postgresql",
+      "tag" : "15"
+    },
+
+  })
+}
+
+#
+# Prepare locals.
+#
+
+locals {
+  seal_metadata_project_name     = coalesce(var.seal_metadata_project_name, "example")
+  seal_metadata_environment_name = coalesce(var.seal_metadata_environment_name, "example")
+  seal_metadata_service_name     = coalesce(var.seal_metadata_service_name, "rds")
+
+  identifier = join("-", [local.seal_metadata_project_name, local.seal_metadata_environment_name, local.seal_metadata_service_name])
+}
+
+locals {
+  engineInfo = lookup(local.engineInfos, var.engine)
+
+  architecture = var.architecture
+
+  namespace  = local.identifier
+  name       = local.seal_metadata_service_name
+  chart      = lookup(local.engineInfo, "chart")
+  repository = lookup(local.engineInfo, "repository")
+  tag        = lookup(local.engineInfo, "tag")
+  driver     = lookup(local.engineInfo, "driver")
+  port       = lookup(local.engineInfo, "port")
+  database   = var.database
+  username   = var.username
+  password   = var.password
+
+  init_sql_url       = var.init_sql_url
+  emphemeral_storage = var.emphemeral_storage
+}
+
+#
+# Install by Helm Chart.
+#
+
+resource "helm_release" "rds" {
+  repository       = "https://charts.bitnami.com/bitnami"
+  chart            = local.chart
+  wait             = false
+  create_namespace = true
+  max_history      = 3
+
+  namespace = local.namespace
+  name      = local.name
+
+  values = [
+    templatefile("${path.module}/templates/values.tftpl", {
+      chart        = local.chart
+      name         = local.name
+      architecture = lower(local.architecture)
+      image = {
+        repository = local.repository
+        tag        = local.tag
+      }
+      auth = {
+        database = local.database
+        username = local.username
+      }
+      persistence = {
+        enabled = !local.emphemeral_storage
+      }
+      init_sql_url = local.init_sql_url
+    })
+  ]
+
+  set_sensitive {
+    name  = "auth.rootPassword"
+    value = local.password
+  }
+  set_sensitive {
+    name  = "auth.postgresPassword"
+    value = local.password
+  }
+  set_sensitive {
+    name  = "auth.replicationPassword"
+    value = local.password
+  }
+  set_sensitive {
+    name  = "auth.password"
+    value = local.password
+  }
+}
+
+#
+# Get host/endpoint.
+#
+
+data "kubernetes_service_v1" "rds" {
+  depends_on = [helm_release.rds]
+
+  metadata {
+    namespace = local.namespace
+    name      = local.architecture == "Replication" ? format("%s-primary", local.name) : local.name
+  }
+}
+
+data "kubernetes_service_v1" "rds_replica" {
+  count = local.architecture == "Replication" ? 1 : 0
+
+  depends_on = [helm_release.rds]
+
+  metadata {
+    namespace = local.namespace
+    name      = format("%s-secondary", local.name)
+  }
+}
+
+locals {
+  host             = format("%s.%s.svc", data.kubernetes_service_v1.rds.metadata.0.name, local.namespace)
+  host_replica     = local.architecture == "Replication" ? format("%s.%s.svc", data.kubernetes_service_v1.rds_replica.0.metadata.0.name, local.namespace) : null
+  endpoint         = try(data.kubernetes_service_v1.rds.spec.0.cluster_ip, null)
+  endpoint_replica = try(data.kubernetes_service_v1.rds_replica.0.spec.0.cluster_ip, null)
+}

--- a/rds/0.0.1/outputs.tf
+++ b/rds/0.0.1/outputs.tf
@@ -1,0 +1,36 @@
+output "db_endpoint" {
+  value = local.endpoint
+}
+
+output "db_host" {
+  value = local.host
+}
+
+output "db_endpoint_replica" {
+  value = local.endpoint_replica
+}
+
+output "db_host_replica" {
+  value = local.host_replica
+}
+
+output "db_driver" {
+  value = local.driver
+}
+
+output "db_port" {
+  value = local.port
+}
+
+output "db_name" {
+  value = local.database
+}
+
+output "db_username" {
+  value = local.username
+}
+
+output "db_password" {
+  sensitive = true
+  value     = local.password
+}

--- a/rds/0.0.1/templates/values.tftpl
+++ b/rds/0.0.1/templates/values.tftpl
@@ -1,0 +1,61 @@
+{
+  "fullnameOverride": "${name}",
+
+  "architecture": "${architecture}",
+
+  "image": {
+    "repository": "${image.repository}",
+    "tag": "${image.tag}"
+  },
+
+  "auth": {
+    "database": "${auth.database}",
+    "username": "${auth.username}"
+  },
+
+  "primary": {
+    "name": "primary",
+%{ if init_sql_url != "" }
+    "initContainers": [
+      {
+        "name": "init-sql",
+        "image": "alpine",
+        "command": [ "wget", "-c", "-S", "-P", "/docker-entrypoint-initdb.d", "${init_sql_url}" ],
+        "volumeMounts": [
+          {
+            "name": "init-sql",
+            "mountPath": "/docker-entrypoint-initdb.d"
+          }
+        ]
+      }
+    ],
+%{ endif }
+    "persistence": {
+      "enabled": ${persistence.enabled},
+    },
+    "extraVolumeMounts":[
+      {
+        "name": "init-sql",
+        "mountPath": "/docker-entrypoint-initdb.d"
+      }
+    ],
+    "extraVolumes": [
+      {
+        "name": "init-sql",
+        "emptyDir": {}
+      }
+    ]
+  },
+
+%{ if chart == "postgresql" }
+  "readReplicas": {
+%{ else }
+  "secondary": {
+%{ endif }
+    "name": "secondary",
+    "persistence": {
+      "enabled": ${persistence.enabled}
+    }
+  },
+
+}

--- a/rds/0.0.1/variables.tf
+++ b/rds/0.0.1/variables.tf
@@ -1,0 +1,125 @@
+##############
+# Basic Group
+##############
+
+# @group "Basic"
+# @label "Engine"
+# @options ["MySQL-5.7","MySQL-8.0","MariaDB-10.3","MariaDB-10.4","MariaDB-10.5","MariaDB-10.6","PostgreSQL-13","PostgreSQL-14","PostgreSQL-15"]
+variable "engine" {
+  type        = string
+  description = "Select the RDS engine, support serval kinds of 'MySQL', 'MariaDB' and 'PostgreSQL'."
+
+  validation {
+    condition     = contains(["MySQL-5.7", "MySQL-8.0", "MariaDB-10.3", "MariaDB-10.4", "MariaDB-10.5", "MariaDB-10.6", "PostgreSQL-13", "PostgreSQL-14", "PostgreSQL-15"], var.engine)
+    error_message = "Invalid engine"
+  }
+}
+
+# @group "Basic"
+# @label "Architecture"
+# @options ["Standalone","Replication"]
+variable "architecture" {
+  type        = string
+  description = "Select the RDS architecture, support from 'Standalone' and 'Replication'."
+
+  validation {
+    condition     = contains(["Standalone", "Replication"], var.architecture)
+    error_message = "Invalid architecture"
+  }
+}
+
+# @group "Basic"
+# @label "Password"
+variable "password" {
+  type        = string
+  description = "Specify the root password to initialize after launching."
+
+  validation {
+    condition     = var.password != "" ? can(regex("^[A-Za-z0-9\\!#\\$%\\^&\\*\\(\\)_\\+\\-=]{8,32}", var.password)) : true
+    error_message = "Invalid password"
+  }
+}
+
+# @group "Basic"
+# @label "Username"
+variable "username" {
+  type        = string
+  description = "Specify the root username to initialize after launching, 'MySQL' and 'MariaDB' engines don't allow 'root'."
+  default     = "rdsusr"
+
+  validation {
+    condition     = can(regex("^[^pg][a-z][a-z0-9_]{0,61}[a-z0-9]$", var.username))
+    error_message = format("Invalid username: %s", var.username)
+  }
+}
+
+# @group "Basic"
+# @label "Database"
+variable "database" {
+  type        = string
+  description = "Specify the database name to initialize after launching."
+  default     = "rdsdb"
+
+  validation {
+    condition     = can(regex("^[a-z][-a-z0-9_]{0,61}[a-z0-9]$", var.database))
+    error_message = format("Invalid database: %s", var.database)
+  }
+}
+
+#################
+# Advanced Group
+#################
+
+# @group "Advanced"
+# @label "Ephemeral Storage"
+variable "emphemeral_storage" {
+  type        = bool
+  description = "Specify to use emphemeral storage, which is nice for testing."
+  default     = false
+}
+
+# @group "Advanced"
+# @label "Init SQL URL"
+variable "init_sql_url" {
+  type        = string
+  description = "Specify the init SQL download URL to initialize after launching."
+  default     = ""
+
+  validation {
+    condition     = var.init_sql_url != "" ? can(regex("^(?:https?://)+(?:[^/.\\s]+\\.)*", var.init_sql_url)) : true
+    error_message = "Invalid init sql url"
+  }
+}
+
+# @group "Advanced"
+# @label "Namespace"
+variable "namespace" {
+  type        = string
+  description = "Specify the Kubernetes namespace to deploy, generate automatically if empty."
+  default     = ""
+}
+
+###########################
+# Injection Group (Hidden)
+###########################
+
+# @hidden
+variable "seal_metadata_project_name" {
+  type        = string
+  description = "Seal metadata project name."
+  default     = ""
+}
+
+# @hidden
+variable "seal_metadata_environment_name" {
+  type        = string
+  description = "Seal metadata environment name."
+  default     = ""
+}
+
+# @hidden
+variable "seal_metadata_service_name" {
+  type        = string
+  description = "Seal metadata service name."
+  default     = ""
+}

--- a/rds/0.0.1/versions.tf
+++ b/rds/0.0.1/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+
+    helm = {
+      source = "hashicorp/helm"
+    }
+  }
+}

--- a/rds/examples/replication/main.tf
+++ b/rds/examples/replication/main.tf
@@ -1,0 +1,202 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = "~/.kube/config"
+  }
+}
+
+variable "with_mysql" {
+  type    = bool
+  default = false
+}
+
+variable "with_mariadb" {
+  type    = bool
+  default = false
+}
+
+variable "with_postgres" {
+  type    = bool
+  default = false
+}
+
+resource "random_string" "password" {
+  length  = 16
+  special = false
+}
+
+########
+# MySQL
+########
+
+module "mysql" {
+  count = var.with_mysql ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "MySQL-8.0"
+  architecture = "Replication"
+  password     = random_string.password.result
+
+  emphemeral_storage = true
+  init_sql_url       = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/mysql-lg.sql"
+
+  seal_metadata_service_name = "mysql"
+}
+
+output "mysql_db_endpoint" {
+  value = try(module.mysql.0.db_endpoint, null)
+}
+
+output "mysql_db_host" {
+  value = try(module.mysql.0.db_host, null)
+}
+
+output "mysql_db_endpoint_replica" {
+  value = try(module.mysql.0.db_endpoint_replica, null)
+}
+
+output "mysql_db_host_replica" {
+  value = try(module.mysql.0.db_host_replica, null)
+}
+
+output "mysql_db_driver" {
+  value = try(module.mysql.0.db_driver, null)
+}
+
+output "mysql_db_port" {
+  value = try(module.mysql.0.db_port, null)
+}
+
+output "mysql_db_name" {
+  value = try(module.mysql.0.db_name, null)
+}
+
+output "mysql_db_username" {
+  value = try(module.mysql.0.db_username, null)
+}
+
+output "mysql_db_password" {
+  sensitive = true
+  value     = try(module.mysql.0.db_password, null)
+}
+
+##########
+# MariaDB
+##########
+
+module "mariadb" {
+  count = var.with_mariadb ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "MariaDB-10.3"
+  architecture = "Replication"
+  password     = random_string.password.result
+
+  emphemeral_storage = true
+  init_sql_url       = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/mysql.sql"
+
+  seal_metadata_service_name = "mariadb"
+}
+
+output "mariadb_db_endpoint" {
+  value = try(module.mariadb.0.db_endpoint, null)
+}
+
+output "mariadb_db_host" {
+  value = try(module.mariadb.0.db_host, null)
+}
+
+output "mariadb_db_endpoint_replica" {
+  value = try(module.mariadb.0.db_endpoint_replica, null)
+}
+
+output "mariadb_db_host_replica" {
+  value = try(module.mariadb.0.db_host_replica, null)
+}
+
+output "mariadb_db_driver" {
+  value = try(module.mariadb.0.db_driver, null)
+}
+
+output "mariadb_db_port" {
+  value = try(module.mariadb.0.db_port, null)
+}
+
+output "mariadb_db_name" {
+  value = try(module.mariadb.0.db_name, null)
+}
+
+output "mariadb_db_username" {
+  value = try(module.mariadb.0.db_username, null)
+}
+
+output "mariadb_db_password" {
+  sensitive = true
+  value     = try(module.mariadb.0.db_password, null)
+}
+
+############
+#PostgreSQL
+############
+
+module "postgres" {
+  count = var.with_postgres ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "PostgreSQL-13"
+  architecture = "Replication"
+  password     = random_string.password.result
+  username     = "root"
+
+  emphemeral_storage = true
+  init_sql_url       = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/postgres-lg.sql"
+
+  seal_metadata_service_name = "postgres"
+}
+
+output "postgres_db_endpoint" {
+  value = try(module.postgres.0.db_endpoint, null)
+}
+
+output "postgres_db_host" {
+  value = try(module.postgres.0.db_host, null)
+}
+
+output "postgres_db_endpoint_replica" {
+  value = try(module.postgres.0.db_endpoint_replica, null)
+}
+
+output "postgres_db_host_replica" {
+  value = try(module.postgres.0.db_host_replica, null)
+}
+
+output "postgres_db_driver" {
+  value = try(module.postgres.0.db_driver, null)
+}
+
+output "postgres_db_port" {
+  value = try(module.postgres.0.db_port, null)
+}
+
+output "postgres_db_name" {
+  value = try(module.postgres.0.db_name, null)
+}
+
+output "postgres_db_username" {
+  value = try(module.postgres.0.db_username, null)
+}
+
+output "postgres_db_password" {
+  sensitive = true
+  value     = try(module.postgres.0.db_password, null)
+}

--- a/rds/examples/standalone/main.tf
+++ b/rds/examples/standalone/main.tf
@@ -1,0 +1,202 @@
+terraform {
+  required_version = ">= 1.0"
+}
+
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = "~/.kube/config"
+  }
+}
+
+variable "with_mysql" {
+  type    = bool
+  default = false
+}
+
+variable "with_mariadb" {
+  type    = bool
+  default = false
+}
+
+variable "with_postgres" {
+  type    = bool
+  default = false
+}
+
+resource "random_string" "password" {
+  length  = 16
+  special = false
+}
+
+########
+# MySQL
+########
+
+module "mysql" {
+  count = var.with_mysql ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "MySQL-8.0"
+  architecture = "Standalone"
+  password     = random_string.password.result
+
+  emphemeral_storage = true
+  init_sql_url       = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/mysql-lg.sql"
+
+  seal_metadata_service_name = "mysql"
+}
+
+output "mysql_db_endpoint" {
+  value = try(module.mysql.0.db_endpoint, null)
+}
+
+output "mysql_db_host" {
+  value = try(module.mysql.0.db_host, null)
+}
+
+output "mysql_db_endpoint_replica" {
+  value = try(module.mysql.0.db_endpoint_replica, null)
+}
+
+output "mysql_db_host_replica" {
+  value = try(module.mysql.0.db_host_replica, null)
+}
+
+output "mysql_db_driver" {
+  value = try(module.mysql.0.db_driver, null)
+}
+
+output "mysql_db_port" {
+  value = try(module.mysql.0.db_port, null)
+}
+
+output "mysql_db_name" {
+  value = try(module.mysql.0.db_name, null)
+}
+
+output "mysql_db_username" {
+  value = try(module.mysql.0.db_username, null)
+}
+
+output "mysql_db_password" {
+  sensitive = true
+  value     = try(module.mysql.0.db_password, null)
+}
+
+##########
+# MariaDB
+##########
+
+module "mariadb" {
+  count = var.with_mariadb ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "MariaDB-10.3"
+  architecture = "Standalone"
+  password     = random_string.password.result
+
+  emphemeral_storage = true
+  init_sql_url       = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/mysql.sql"
+
+  seal_metadata_service_name = "mariadb"
+}
+
+output "mariadb_db_endpoint" {
+  value = try(module.mariadb.0.db_endpoint, null)
+}
+
+output "mariadb_db_host" {
+  value = try(module.mariadb.0.db_host, null)
+}
+
+output "mariadb_db_endpoint_replica" {
+  value = try(module.mariadb.0.db_endpoint_replica, null)
+}
+
+output "mariadb_db_host_replica" {
+  value = try(module.mariadb.0.db_host_replica, null)
+}
+
+output "mariadb_db_driver" {
+  value = try(module.mariadb.0.db_driver, null)
+}
+
+output "mariadb_db_port" {
+  value = try(module.mariadb.0.db_port, null)
+}
+
+output "mariadb_db_name" {
+  value = try(module.mariadb.0.db_name, null)
+}
+
+output "mariadb_db_username" {
+  value = try(module.mariadb.0.db_username, null)
+}
+
+output "mariadb_db_password" {
+  sensitive = true
+  value     = try(module.mariadb.0.db_password, null)
+}
+
+############
+#PostgreSQL
+############
+
+module "postgres" {
+  count = var.with_postgres ? 1 : 0
+
+  source = "../../0.0.1"
+
+  engine       = "PostgreSQL-13"
+  architecture = "Standalone"
+  password     = random_string.password.result
+  username     = "root"
+
+  emphemeral_storage = true
+  init_sql_url       = "https://raw.githubusercontent.com/seal-io/terraform-provider-byteset/main/byteset/testdata/postgres-lg.sql"
+
+  seal_metadata_service_name = "postgres"
+}
+
+output "postgres_db_endpoint" {
+  value = try(module.postgres.0.db_endpoint, null)
+}
+
+output "postgres_db_host" {
+  value = try(module.postgres.0.db_host, null)
+}
+
+output "postgres_db_endpoint_replica" {
+  value = try(module.postgres.0.db_endpoint_replica, null)
+}
+
+output "postgres_db_host_replica" {
+  value = try(module.postgres.0.db_host_replica, null)
+}
+
+output "postgres_db_driver" {
+  value = try(module.postgres.0.db_driver, null)
+}
+
+output "postgres_db_port" {
+  value = try(module.postgres.0.db_port, null)
+}
+
+output "postgres_db_name" {
+  value = try(module.postgres.0.db_name, null)
+}
+
+output "postgres_db_username" {
+  value = try(module.postgres.0.db_username, null)
+}
+
+output "postgres_db_password" {
+  sensitive = true
+  value     = try(module.postgres.0.db_password, null)
+}


### PR DESCRIPTION
this PR introduces the following modules, 
- alicloud-rds
- rds (for Kuberentes)
- rds-seeder
and refactor the aws-rds.

the `engine`, `architecture`, and `password` fields are required.
